### PR TITLE
Allow custom timer before cluster join

### DIFF
--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -10,7 +10,7 @@ wait-for-cluster:
 
 wait-for-total-initialization:
   cmd.run:
-    - name: 'sleep 5'
+    - name: 'sleep {{ cluster.join_timer|default(5) }}'
     - require:
       - wait-for-cluster
 

--- a/pillar.example
+++ b/pillar.example
@@ -24,7 +24,8 @@ cluster:
   # optional: UDP instead of multicast
   # unicast: True
   
-  # optional: Increase default timer before joining a cluster
+  # optional: Time in seconds between hawk service is available in the first
+  # node and join command is executed (5s by default)
   # join_timer: 5
 
   # optional: Configure a virtual IP resource in cluster

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,9 @@ cluster:
 
   # optional: UDP instead of multicast
   # unicast: True
+  
+  # optional: Increase default timer before joining a cluster
+  # join_timer: 5
 
   # optional: Configure a virtual IP resource in cluster
   # admin_ip: 10.20.30.40


### PR DESCRIPTION
The sleep time between cluster initialization and cluster join ( 5 seconds ) seems to be not enough in public cloud (Tested with AWS).
- I  added a new pillar item (join_timer) to allow the user the option to customize it. 
Of course, 5 seconds still be the default one if the pillar is not set.