### PR TITLE
Allow pre-configured packages

### DIFF
--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -1,2 +1,3 @@
 cluster:
   name: hacluster
+  install_packages: true

--- a/cluster/init.sls
+++ b/cluster/init.sls
@@ -3,7 +3,9 @@
 
 include:
   - .pre_validation
+{% if cluster.install_packages is sameas true %}
   - .packages
+{% endif %}
   - .resource_agents
 {% if cluster.ntp is defined %}
   - .ntp

--- a/pillar.example
+++ b/pillar.example
@@ -36,6 +36,10 @@ cluster:
   #   # optional: Configure an SBD device
   #   device: /dev/by-label/sbd-disk
 
+  # optional: Install required packages to run the cluster (true by default)
+  # pre-configured packages sometimes exist for development purposes
+  # install_packages: true
+
   # optional: ntp server
   # ntp: pool.ntp.org
 


### PR DESCRIPTION
Pre-configured packages sometimes exists for developement purpose.

When we test a new build, some HA packages are included in the image to test it.
As they are included, when salt try to find the repository for the HA pattern, the command zypper info returns:

`Repository     : @System`

And Salt returns this error:

![screenshot_20190214_171414](https://user-images.githubusercontent.com/6025636/52800432-06393080-307c-11e9-9d19-8b9f2a76b860.png)

The solution is to add a pillar item to inform that pre-configured packages are included and skip the state file packages.sls.

Without this new pillar set, the default choise still be to install the packages.