### PR TITLE
Add chrony support for SLES versions above 15

### DIFF
--- a/cluster/ntp.sls
+++ b/cluster/ntp.sls
@@ -1,8 +1,8 @@
 {%- from "cluster/map.jinja" import cluster with context -%}
 
-ntp_packages:
-  pkg.installed:
-  - name: ntp
+{% if grains['osmajorrelease']|int == 12 %}
+ntp:
+  pkg.installed
 
 /etc/ntp.conf:
   file.append:
@@ -14,3 +14,19 @@ ntpd:
   - enable: True
   - watch:
     - file: /etc/ntp.conf
+
+{% else %} # SLES15
+chrony:
+  pkg.installed
+
+/etc/chrony.conf:
+  file.append:
+  - text:
+    - server {{ cluster.ntp }}
+
+chronyd:
+  service.running:
+  - enable: True
+  - watch:
+    - file:  /etc/chrony.conf
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -23,7 +23,7 @@ cluster:
 
   # optional: UDP instead of multicast
   # unicast: True
-  
+
   # optional: Time in seconds between hawk service is available in the first
   # node and join command is executed (5s by default)
   # join_timer: 5


### PR DESCRIPTION
Now we will use chrony instead of ntp in SLES15 and above. The configuration is exactly the same, so it won't affect to the user. The pillar will work the same way

https://github.com/SUSE/ha-sap-terraform-deployments/issues/65

Some more context after the execution:
```
ec2-user@hana01:~> timedatectl
      Local time: Tue 2019-04-16 11:06:10 UTC
  Universal time: Tue 2019-04-16 11:06:10 UTC
        RTC time: Tue 2019-04-16 11:06:10
       Time zone: UTC (UTC, +0000)
 Network time on: no
NTP synchronized: yes
 RTC in local TZ: no

```

**Disclaimer: This won't work with some old salt versions as 'osmajorrelease' variable is not available.**