### PR TITLE
Install the Salt files on the salt-shared location from 15-SP1

### DIFF
--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,7 +1,18 @@
 -------------------------------------------------------------------
+Fri May 31 13:14:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
+
+- Version bump 0.1.1
+  * Include the salt-formulas-configuration dependency on
+    SLE/Leap 15-SP1 and higher. This package configures the shared salt
+    formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0
+    or salt in standalone mode.
+  * Drops the habootstrap-formula-suma package, as the forms metadata
+    will be available only on SUMA 4.0 using the shared location.
+
+-------------------------------------------------------------------
 Thu May 16 09:13:17 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
-- Remove network repository installation 
+- Remove network repository installation
 
 -------------------------------------------------------------------
 Thu Apr 25 12:26:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
@@ -44,4 +55,4 @@ Thu Sep 06 13:25:22 UTC 2018 - kgronlund@suse.com
 Thu Sep  6 12:37:13 UTC 2018 - kgronlund@suse.com
 
 - Initial version
- 
+

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri May 31 13:14:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
 
-- Version bump 0.1.1
+- Version bump 0.2.0
   * Include the salt-formulas-configuration dependency on
     SLE/Leap 15-SP1 and higher. This package configures the shared salt
     formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.1.1
+Version:        0.2.0
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula


### PR DESCRIPTION
- Version bump 0.1.1
  * Include the salt-formulas-configuration dependency on
    SLE/Leap 15-SP1 and higher. This package configures the shared salt
    formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0
    or salt in standalone mode.
  * Drops the habootstrap-formula-suma package, as the forms metadata
    will be available only on SUMA 4.0 using the shared location.