### PR TITLE
Increase the default join_timer for pacemaker starting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ systemctl start libvirtd
 ```
 
 ### Known issues
-* Failed to run [wait-for-total-initialization](./cluster/join.sls):
+* Failure running [join-the-cluster](./cluster/join.sls):
 
-> Note: The current solution is the query **hawk** status, can't exactly
-> represent the state of **pacemaker**. Increase the `join_timer` to
-> wait pacemaker may help in some cases.
+> Note: The current solution is to query **hawk** status. This doesn't exactly
+> represent the state of **pacemaker** (hawk initialization is independent).
+> Increasing the `join_timer` to wait pacemaker may help in some cases.
 
 TODO: Replace to query **hawk** by checking **pacemaker** directly.

--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ To run the tests, `libvirt` must be installed and the daemon running:
 zypper in libvirt
 systemctl start libvirtd
 ```
+
+### Known issues
+* Failed to run [wait-for-total-initialization](./cluster/join.sls):
+
+> Note: The current solution is the query **hawk** status, can't exactly
+> represent the state of **pacemaker**. Increase the `join_timer` to
+> wait pacemaker may help in some cases.
+
+TODO: Replace to query **hawk** by checking **pacemaker** directly.

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -10,7 +10,7 @@ wait-for-cluster:
 
 wait-for-total-initialization:
   cmd.run:
-    - name: 'sleep {{ cluster.join_timer|default(5) }}'
+    - name: 'sleep {{ cluster.join_timer|default(20) }}'
     - require:
       - wait-for-cluster
 

--- a/pillar.example
+++ b/pillar.example
@@ -25,8 +25,8 @@ cluster:
   # unicast: True
 
   # optional: Time in seconds between hawk service is available in the first
-  # node and join command is executed (5s by default)
-  # join_timer: 5
+  # node and join command is executed (20s by default)
+  # join_timer: 20
 
   # optional: Configure a virtual IP resource in cluster
   # admin_ip: 10.20.30.40


### PR DESCRIPTION
5s default time is too short to pacemaker, increase to 20s.
May need to find a better solution instead of querying hawk in future.