### PR TITLE
Fix issue with file permissions for SUMA

### DIFF
--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 22 08:29:00 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Version bump 0.2.4
+  * Fix issue with file permissions during package installation in
+    /usr/share/salt-formulas
+    (boo#1142306)  
+
+-------------------------------------------------------------------
 Fri Jul  5 12:24:40 UTC 2019 - Dario Maiocchi <dmaiocchi@suse.com>
 
 - Make pkg.install more resilient, allowing retries during install

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.2.3
+Version:        0.2.4
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula
@@ -35,7 +35,7 @@ Requires:       salt-shaptools
 
 # On SLE/Leap 15-SP1 and TW requires the new salt-formula configuration location.
 %if ! (0%{?sle_version:1} && 0%{?sle_version} < 150100)
-Requires:       salt-standalone-formulas-configuration
+Requires:       salt-formulas-configuration
 %endif
 
 %description
@@ -96,9 +96,9 @@ fi
 %{fdir}/states/%{fname}
 %{fdir}/metadata/%{fname}
 
-%dir %attr(0750, root, salt) %{fdir}
-%dir %attr(0750, root, salt) %{fdir}/states
-%dir %attr(0750, root, salt) %{fdir}/metadata
+%dir %attr(-, root, root) %{fdir}
+%dir %attr(-, root, root) %{fdir}/states
+%dir %attr(-, root, root) %{fdir}/metadata
 
 %endif
 


### PR DESCRIPTION
Tested in environment with SUMA and the formulas are installed properly without breaking SUMA webpage.

INFO: uninstalling the package still removes `/usr/share/salt-formulas` folder breaking SUMA webpage