### PR TITLE
Add customizable timeout value to join process

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,6 @@ systemctl start libvirtd
 
 > Note: The current solution is to query **hawk** status. This doesn't exactly
 > represent the state of **pacemaker** (hawk initialization is independent).
-> Increasing the `join_timer` to wait pacemaker may help in some cases.
+> Increasing the `wait_for_initialization` to wait pacemaker may help in some cases.
 
 TODO: Replace to query **hawk** by checking **pacemaker** directly.

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -1,3 +1,5 @@
 cluster:
   name: hacluster
   install_packages: true
+  join_timeout: 60
+  join_timer: 20

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -2,4 +2,4 @@ cluster:
   name: hacluster
   install_packages: true
   join_timeout: 60
-  join_timer: 20
+  wait_for_initialization: 20

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -6,11 +6,11 @@ wait-for-cluster:
     - request_interval: 5
     - status: 200
     - verify_ssl: false
-    - wait_for: 60
+    - wait_for: {{ cluster.join_timeout }}
 
 wait-for-total-initialization:
   cmd.run:
-    - name: 'sleep {{ cluster.join_timer|default(20) }}'
+    - name: 'sleep {{ cluster.join_timer }}'
     - require:
       - wait-for-cluster
 

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -10,7 +10,7 @@ wait-for-cluster:
 
 wait-for-total-initialization:
   cmd.run:
-    - name: 'sleep {{ cluster.join_timer }}'
+    - name: 'sleep {{ cluster.wait_for_initialization }}'
     - require:
       - wait-for-cluster
 

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 16 01:26:50 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Add customizable timeout to the join process 
+
+-------------------------------------------------------------------
 Wed Sep 18 07:51:22 UTC 2019 - Dario Maiocchi <dmaiocchi@suse.com>
 
 - remove and replace hawk-apiserver with prometheus-ha_cluster_exporter pkg 

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,19 +1,21 @@
 -------------------------------------------------------------------
 Wed Oct 16 01:26:50 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
-- Add customizable timeout to the join process 
+- Version bump 0.2.8
+  *Add customizable timeout to the join process and rename join_timer to
+   wait_for_initialization
 
 -------------------------------------------------------------------
 Wed Sep 18 07:51:22 UTC 2019 - Dario Maiocchi <dmaiocchi@suse.com>
 
-- remove and replace hawk-apiserver with prometheus-ha_cluster_exporter pkg 
+- remove and replace hawk-apiserver with prometheus-ha_cluster_exporter pkg
 
 -------------------------------------------------------------------
 Wed Sep  4 07:04:48 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Update the pkg.info_available call to avoid repositories refresh as
   it may cause errors
-- Add packages and ha_exporter options to the SUMA form.yml file 
+- Add packages and ha_exporter options to the SUMA form.yml file
 
 -------------------------------------------------------------------
 Sun Aug 25 17:58:31 UTC 2019 - Ayoub Belarbi <abelarbi@suse.de>

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.2.7
+Version:        0.2.8
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula

--- a/pillar.example
+++ b/pillar.example
@@ -28,6 +28,9 @@ cluster:
   # node and join command is executed (20s by default)
   # join_timer: 20
 
+  # optional: Timeout in seconds to join to the cluster
+  # join_timeout: 60
+
   # optional: Configure a virtual IP resource in cluster
   # admin_ip: 10.20.30.40
 

--- a/pillar.example
+++ b/pillar.example
@@ -26,7 +26,7 @@ cluster:
 
   # optional: Time in seconds between hawk service is available in the first
   # node and join command is executed (20s by default)
-  # join_timer: 20
+  # wait_for_initialization: 20
 
   # optional: Timeout in seconds to join to the cluster
   # join_timeout: 60


### PR DESCRIPTION
My unique concern is about the naming convention. `join_timeout` makes sense but the old `join_timer` is really confusing name...
Maybe we should change it now that we can to something like `wait_for_hawk` or similar.
What do you think?