### PR TITLE
Install `socat` on the Azure 

### DIFF
--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -39,3 +39,13 @@ install_cluster_packages:
       - sbd
 
 {% endif %}
+
+{% if grains['provider'] == "azure" %}
+# Install socat utility on Azure platform (to replace netcat)
+install_additional_packages_azure:
+  pkg.installed:
+    - retry:
+        attempts: 3
+        interval: 15
+    - pkgs:
+      - socat


### PR DESCRIPTION
Azure changed the Load-Balancer listener to `socat` as `netcat` does not allow more than one concurrent connection. For that, we need to install the package socat,  and corropondingly our template for HANA (and Netweaver in the future) needs to be adapted to use the updated command, instead of the old `nc` command.

Reference:
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources