### PR TITLE
Install `socat` on the Azure 

### DIFF
--- a/ci/validate-formula.sh
+++ b/ci/validate-formula.sh
@@ -61,7 +61,6 @@ echo "==========================================="
 
 cat >grains <<EOF
 host: hana01
-provider: azure
 EOF
 
 cat >minion <<EOF
@@ -79,7 +78,6 @@ echo "==========================================="
 generate_cluster_pillar "init: 'hana01'"
 cat >grains <<EOF
 host: hana02
-provider: azure
 EOF
 
 cat >minion <<EOF
@@ -97,7 +95,6 @@ echo "==========================================="
 generate_cluster_pillar "init: 'hana01'"
 cat >grains <<EOF
 host: hana03
-provider: azure
 EOF
 
 cat >minion <<EOF

--- a/ci/validate-formula.sh
+++ b/ci/validate-formula.sh
@@ -61,6 +61,7 @@ echo "==========================================="
 
 cat >grains <<EOF
 host: hana01
+provider: azure
 EOF
 
 cat >minion <<EOF
@@ -78,6 +79,7 @@ echo "==========================================="
 generate_cluster_pillar "init: 'hana01'"
 cat >grains <<EOF
 host: hana02
+provider: azure
 EOF
 
 cat >minion <<EOF
@@ -95,6 +97,7 @@ echo "==========================================="
 generate_cluster_pillar "init: 'hana01'"
 cat >grains <<EOF
 host: hana03
+provider: azure
 EOF
 
 cat >minion <<EOF

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -1,6 +1,7 @@
 #required packages to install HA cluster
 
 {%- from "cluster/map.jinja" import cluster with context -%}
+{% set provider = pillar.cluster.configure.template.parameters.platform %}
 
 {% set pattern_available = 1 %}
 {% if grains['os_family'] == 'Suse' %}
@@ -40,7 +41,7 @@ install_cluster_packages:
 
 {% endif %}
 
-{% if grains['provider'] == "azure" %}
+{% if provider == "azure" %}
 # Install socat utility on Azure platform (to replace netcat)
 install_additional_packages_azure:
   pkg.installed:

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -48,4 +48,3 @@ install_additional_packages_azure:
         interval: 15
     - pkgs:
       - socat
-{% endif %}

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -39,3 +39,14 @@ install_cluster_packages:
       - sbd
 
 {% endif %}
+
+{% if grains['provider'] == "azure" %}
+# Install socat utility on Azure platform (to replace netcat)
+install_additional_packages_azure:
+  pkg.installed:
+    - retry:
+        attempts: 3
+        interval: 15
+    - pkgs:
+      - socat
+{% endif %}

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -1,7 +1,7 @@
 #required packages to install HA cluster
 
 {%- from "cluster/map.jinja" import cluster with context -%}
-{% set provider = pillar.cluster.configure.template.parameters.platform %}
+{% set provider = cluster.configure.template.parameters.platform|default('libvirt') %}
 
 {% set pattern_available = 1 %}
 {% if grains['os_family'] == 'Suse' %}

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -1,7 +1,6 @@
 #required packages to install HA cluster
 
 {%- from "cluster/map.jinja" import cluster with context -%}
-{% set provider = cluster.configure.template.parameters.platform|default('libvirt') %}
 
 {% set pattern_available = 1 %}
 {% if grains['os_family'] == 'Suse' %}
@@ -41,8 +40,7 @@ install_cluster_packages:
 
 {% endif %}
 
-{% if provider == "azure" %}
-# Install socat utility on Azure platform (to replace netcat)
+# socat utility required only for Azure platform 
 install_additional_packages_azure:
   pkg.installed:
     - retry:

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Nov 28 19:17:37 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Install 'socat' package on the Azure platform
+  
+-------------------------------------------------------------------
 Wed Oct 30 16:14:32 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.2.9

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.3.0
+Version:        0.2.10
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.2.9
+Version:        0.3.0
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula


### PR DESCRIPTION
This PR installs the `socat` tool to replace 'netcat' on the azure platform
-Also to validate CI, added the provider info(azure) to grains 

**Background:**
Azure changed the Load-Balancer listener to `socat` as `netcat` does not allow more than one concurrent connection. For that, we need to install the package socat, and corropondingly our template for HANA (and Netweaver in the future) needs to be adapted to use the updated command, instead of the old `nc` command.

**Reference:**
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources