### PR TITLE
Add --no-overwrite-sshkey option

### DIFF
--- a/cluster/create.sls
+++ b/cluster/create.sls
@@ -23,6 +23,7 @@ bootstrap-the-cluster:
      - sbd_dev: {{ cluster.sbd.device }}
      {% endif %}
      {% endif %}
+     - no_overwrite_sshkey: {{ not cluster.sshkeys.overwrite }}
 
 {% if cluster.configure is defined %}
 {% set url = none %}

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -3,3 +3,5 @@ cluster:
   install_packages: true
   join_timeout: 60
   wait_for_initialization: 20
+  sshkeys:
+    overwrite: false

--- a/cluster/init.sls
+++ b/cluster/init.sls
@@ -10,11 +10,7 @@ include:
 {% if cluster.ntp is defined %}
   - .ntp
 {% endif %}
-{% if cluster.sshkeys is defined  %}
-{% if cluster.sshkeys.password is defined %}
   - .sshkeys
-{% endif %}
-{% endif %}
 {% if cluster.watchdog is defined %}
 {% if cluster.watchdog.module is defined %}
   - .watchdog

--- a/cluster/sshkeys.sls
+++ b/cluster/sshkeys.sls
@@ -1,6 +1,5 @@
 {% from "cluster/map.jinja" import cluster with context %}
 {% set host = grains['host'] %}
-{% set password = cluster.sshkeys.password %}
 
 create_ssh_directory:
  file.directory:
@@ -11,10 +10,14 @@ create_ssh_directory:
 
 {% if cluster.init != host %}
 
-{% if cluster.sshkeys.overwrite is defined and cluster.sshkeys.overwrite is sameas true %}
+{% if cluster.sshkeys.get('password', False) %}
+{% set password = cluster.sshkeys.get('password') %}
+
+# Create a temporary key to provide access for the joining node to the 1st node
+{% if cluster.sshkeys.overwrite is sameas true %}
 create_key:
   cmd.run:
-    - name: yes y | sudo ssh-keygen -f /root/.ssh/id_rsa -C 'Initial key' -N ''
+    - name: yes y | sudo ssh-keygen -f /root/.ssh/id_rsa -C 'Cluster key' -N ''
 {% endif %}
 
 copy_ask_pass:
@@ -60,4 +63,16 @@ rm_ssh_pub:
     - require:
       - copy_ssh_pub
 
+{% endif %}
+{% endif %}
+
+# ssh keys must always exist if overwrite is false or if the node is joining
+{% if cluster.sshkeys.overwrite is sameas false or cluster.init != host %}
+check_sshkey_exists:
+  file.exists:
+    - name: /root/.ssh/id_rsa
+
+check_sshkey_pub_exists:
+  file.exists:
+    - name: /root/.ssh/id_rsa.pub
 {% endif %}

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec 11 11:38:44 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Add --no-overwrite-sshkey option to the formula 
+ 
+-------------------------------------------------------------------
 Thu Nov 28 19:17:37 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Install 'socat' package on the Azure platform

--- a/pillar.example
+++ b/pillar.example
@@ -49,12 +49,18 @@ cluster:
   # optional: enable ha_exporter by default disabled
   ha_exporter: true
 
-  # optional: Authorize ssh connection from nodes to willing to join
+  # optional: Manage ssh keys usage
+  # If this entry is not set, the formula expects that the sshkeys exist and are authorized among the nodes
+  # Use cases:
+  # 1. ssh keys already exist and nodes are authorized to ssh each other. Don't set this entry
+  # 2. ssh keys already exist but you want to overwrite them with random new keys, set overwrite to true
+  # 3. ssh keys don't exist and you have the 1st node password. Use this example
+  # 4. If ssh keys don't exist and you don't want to set the password here, the cluster cannot be created!
   # ssheys:
-  #   # Overwrite current keys
-  #   overwrite: true
-  #   # First node root password
-  #   password: admin
+  #   # Overwrite current keys (new keys are created if no keys are found)
+  #   overwrite: true # false by default
+  #   # First node root password. This entry is used to configure the authorized_keys file from the joining nodes
+  #   password: admin # not set by default
 
   # optional: Resource agents packages to install
   # resource_agents:


### PR DESCRIPTION
--no-overwrite-sshkey option implemented.

Now, the sshkey is NOT overwritten by default. The use cases are:
1. ssh keys already exist and nodes are authorized to ssh each other. Don't set this entry
2. ssh keys already exist but you want to overwrite them with random new keys, set overwrite to true
3. ssh keys don't exist and you have the 1st node password. Use this example
4. If ssh keys don't exist and you don't want to set the password here, the cluster cannot be created! The formula will fail

Depends on: https://github.com/SUSE/salt-shaptools/pull/42