### PR TITLE
Create new state to configure the cluster

### DIFF
--- a/cluster/configure_resources.sls
+++ b/cluster/configure_resources.sls
@@ -1,0 +1,30 @@
+{%- from "cluster/map.jinja" import cluster with context -%}
+{% set host = grains['host'] %}
+
+{% if cluster.configure is defined %}
+{% set url = none %}
+{% if cluster.configure.template is defined %}
+{% set url = cluster.configure.template.destination|default('/tmp/cluster.config') %}
+{{ url }}:
+  file.managed:
+    - source: {{ cluster.configure.template.source }}
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+{% endif %}
+
+configure-the-cluster:
+  crm.cluster_configured:
+    - name: {{ cluster.configure.method }}
+    - url: {{ cluster.configure.url|default(url) }}
+    {% if cluster.configure.is_xml is defined %}
+    - is_xml: {{ cluster.configure.is_xml }}
+    {% endif %}
+    - require:
+        {% if cluster.init == host %}
+        - bootstrap-the-cluster
+        {% else %}
+        - join-the-cluster
+        {% endif %}
+{% endif %}

--- a/cluster/create.sls
+++ b/cluster/create.sls
@@ -24,30 +24,6 @@ bootstrap-the-cluster:
      {% endif %}
      {% endif %}
 
-{% if cluster.configure is defined %}
-{% set url = none %}
-{% if cluster.configure.template is defined %}
-{% set url = cluster.configure.template.destination|default('/tmp/cluster.config') %}
-{{ url }}:
-  file.managed:
-    - source: {{ cluster.configure.template.source }}
-    - user: root
-    - group: root
-    - mode: 644
-    - template: jinja
-{% endif %}
-
-configure-the-cluster:
-  crm.cluster_configured:
-    - name: {{ cluster.configure.method }}
-    - url: {{ cluster.configure.url|default(url) }}
-    {% if cluster.configure.is_xml is defined %}
-    - is_xml: {{ cluster.configure.is_xml }}
-    {% endif %}
-    - require:
-        - bootstrap-the-cluster
-{% endif %}
-
 hawk:
   service.running:
     - enable: True

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -3,3 +3,4 @@ cluster:
   install_packages: true
   join_timeout: 60
   wait_for_initialization: 20
+  remove: []

--- a/cluster/init.sls
+++ b/cluster/init.sls
@@ -22,10 +22,13 @@ include:
 {% endif %}
 {% if cluster.init == host %}
   - .create
-{% elif cluster.remove is defined and host in cluster.remove %}
+{% elif host in cluster.remove %}
   - .remove
 {% else %}
   - .join
+{% endif %}
+{% if host not in cluster.remove %}
+  - .configure_resources
 {% endif %}
 {% if cluster.ha_exporter is sameas true %}
   - .monitoring

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 11 12:13:43 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Move the cluster configure part to a new state to be executed
+  even when joining executions.  
+
+-------------------------------------------------------------------
 Thu Nov 28 19:17:37 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Install 'socat' package on the Azure platform


### PR DESCRIPTION
With this change the cluster is configured when it's created in the 1st node and when any new node joins.
This fixes the scenario where you want to update the configuration but you are only joining a new node to the cluster.