### PR TITLE
Upgrade package version to 0.3.0

### DIFF
--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,28 +1,13 @@
 -------------------------------------------------------------------
-Wed Jan 08 11:38:44 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+Mon Feb  3 08:58:55 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
-- Add --no-overwrite-sshkey option to the formula
-
--------------------------------------------------------------------
-Mon Dec 16 09:33:20 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
-
-- Add automatic cloud detection
-
--------------------------------------------------------------------
-Wed Dec 11 15:55:33 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
-
-- Add option to set multiple sbd disks to the cluster
-
--------------------------------------------------------------------
-Wed Dec 11 12:13:43 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
-
-- Move the cluster configure part to a new state to be executed
-  even when joining executions.
-
--------------------------------------------------------------------
-Wed Dec 11 09:46:41 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
-
-- Add option to update hacluster user password
+- Version bump 0.3.0
+  * Add --no-overwrite-sshkey option to the formula
+  * Add automatic cloud detection
+  * Add option to set multiple sbd disks to the cluster
+  * Move the cluster configure part to a new state to be executed
+    even when joining executions
+  * Add option to update hacluster user password
 
 -------------------------------------------------------------------
 Thu Nov 28 19:17:37 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.2.10
+Version:        0.3.0
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula


### PR DESCRIPTION
Upgrade package version to 0.3.0.

We had many changes done without upgrading the package version. I have packed all of them in the same new version.

PD: I was waiting for the last crmsh changes to reach SCC  channels to release the new version with `-no-sshoverwrite` option in https://github.com/SUSE/habootstrap-formula/pull/35