### PR TITLE
Feature/gcp instance

### DIFF
--- a/cluster/cloud_detection.sls
+++ b/cluster/cloud_detection.sls
@@ -3,5 +3,5 @@
 {% do salt['grains.set']('cloud_provider', salt['crm.detect_cloud']()) %}
 
 {% if grains['cloud_provider'] == 'google-cloud-platform' %}
-{% do salt['grains.set']('gcp_instance_id', salt['http.query'](url='http://metadata.google.internal/computeMetadata/v1/instance/id', header_dict='{"Metadata-Flavor": "Google"}'))['body'] %}
+{% do salt['grains.set']('gcp_instance_id', salt['http.query'](url='http://metadata.google.internal/computeMetadata/v1/instance/id', header_dict={"Metadata-Flavor": "Google"})['body']) %}
 {% endif %}

--- a/cluster/cloud_detection.sls
+++ b/cluster/cloud_detection.sls
@@ -1,3 +1,7 @@
 # crmsh must exist to run crm.detect_cloud
 {% do salt['pkg.install'](name='crmsh') %}
 {% do salt['grains.set']('cloud_provider', salt['crm.detect_cloud']()) %}
+
+{% if grains['cloud_provider'] == 'google-cloud-platform' %}
+{% do salt['grains.set']('gcp_instance_id', salt['http.query'](url='http://metadata.google.internal/computeMetadata/v1/instance/id', header_dict='{"Metadata-Flavor": "Google"}'))['body'] %}
+{% endif %}

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 27 11:13:04 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version bump 0.3.3
+  * Autodetect GCP instance id and add it to the grains file 
+
+-------------------------------------------------------------------
   Thu Mar  5 10:29:22 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.3.2

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -21,7 +21,7 @@
 %define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
-Version:        0.3.2
+Version:        0.3.3
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula


### PR DESCRIPTION
In order to make `fence_gce` work properly, we need to provide the instance id (instance name works too), to the resource agent.

We can retrieve this value just running an internal gcp rest call, and store in the grains file (it makes sense to have it in the grains, as it's an internal static attribute).

This parameter will be used in HANA and NW formulas to create the resource