### PR TITLE
Feature/cluster configure properties

### DIFF
--- a/cluster/configure_resources.sls
+++ b/cluster/configure_resources.sls
@@ -2,6 +2,30 @@
 {% set host = grains['host'] %}
 
 {% if cluster.configure is defined %}
+
+# Configure the cluster properties
+{% if cluster.configure.properties is defined and cluster.configure.properties|length>0 %}
+configure-cluster-properties:
+  crm.cluster_properties_present:
+    - properties: {{ cluster.configure.properties|json }}
+{% endif %}
+
+# Configure the cluster rsc_defaults
+{% if cluster.configure.rsc_defaults is defined and cluster.configure.rsc_defaults|length>0 %}
+configure-cluster-rsc-defaults:
+  crm.cluster_rsc_defaults_present:
+    - rsc_defaults: {{ cluster.configure.rsc_defaults|json }}
+{% endif %}
+
+# Configure the cluster op_defaults
+{% if cluster.configure.op_defaults is defined and cluster.configure.op_defaults|length>0 %}
+configure-cluster-op-defaults:
+  crm.cluster_op_defaults_present:
+    - op_defaults: {{ cluster.configure.op_defaults|json }}
+{% endif %}
+
+# Configure the cluster using a configuration file
+{% if cluster.configure.url is defined or cluster.configure.template is defined %}
 {% set url = none %}
 {% if cluster.configure.template is defined %}
 {% set url = cluster.configure.template.destination|default('/tmp/cluster.config') %}
@@ -16,15 +40,14 @@
 
 configure-the-cluster:
   crm.cluster_configured:
-    - name: {{ cluster.configure.method }}
+    - name: {{ cluster.configure.method|default("update") }}
     - url: {{ cluster.configure.url|default(url) }}
-    {% if cluster.configure.is_xml is defined %}
-    - is_xml: {{ cluster.configure.is_xml }}
-    {% endif %}
+    - is_xml: {{ cluster.configure.is_xml|default(False) }}
     - require:
         {% if cluster.init == host %}
         - bootstrap-the-cluster
         {% else %}
         - join-the-cluster
         {% endif %}
+{% endif %}
 {% endif %}

--- a/cluster/configure_resources.sls
+++ b/cluster/configure_resources.sls
@@ -1,6 +1,9 @@
 {%- from "cluster/map.jinja" import cluster with context -%}
 {% set host = grains['host'] %}
 
+include:
+  - .configure_sbd_resource
+
 {% if cluster.configure is defined %}
 
 # Configure the cluster properties
@@ -43,6 +46,7 @@ configure-the-cluster:
     - name: {{ cluster.configure.method|default("update") }}
     - url: {{ cluster.configure.url|default(url) }}
     - is_xml: {{ cluster.configure.is_xml|default(False) }}
+    - force: {{ cluster.configure.force|default(False) }}
     - require:
         {% if cluster.init == host %}
         - bootstrap-the-cluster

--- a/cluster/configure_sbd_resource.sls
+++ b/cluster/configure_sbd_resource.sls
@@ -1,0 +1,26 @@
+{%- from "cluster/map.jinja" import cluster with context -%}
+{% set host = grains['host'] %}
+
+{% if cluster.sbd is defined and cluster.sbd.configure_resource is defined %}
+
+create-sbd-resource-configuration:
+  file.managed:
+    - name: /tmp/sbd.config
+    - source: salt://cluster/templates/sbd_resource.j2
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - context:
+        configure: {{ cluster.sbd.configure_resource|yaml }}
+
+configure-sbd-resource:
+  crm.cluster_configured:
+    - name: update
+    - url: /tmp/sbd.config
+    - is_xml: False
+    - force: {{ cluster.sbd.configure_resource.force|default(False) }}
+    - require:
+      - create-sbd-resource-configuration
+
+{% endif %}

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 21 10:12:17 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version bump 0.3.6
+  * Add the option to configure the cluster properties and defaults
+  * Add the option to configure the sbd resource parameters
+  (bsc#1170702)
+
+-------------------------------------------------------------------
 Fri May 15 07:25:49 UTC 2020 - Stefano Torresi <stefano.torresi@suse.com>
 
 - Version bump 0.3.5

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -17,8 +17,6 @@
 
 
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
-%define fname cluster
-%define fdir  %{_datadir}/salt-formulas
 
 Name:           habootstrap-formula
 Version:        0.3.5
@@ -33,6 +31,10 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       salt-shaptools
 Requires:       salt-formulas-configuration
+
+%define fname cluster
+%define fdir  %{_datadir}/salt-formulas
+%define ftemplates templates
 
 %description
 HA cluster salt deployment formula. This formula is capable to perform
@@ -49,6 +51,7 @@ or via SUSE Manager formulas with forms, available on SUSE Manager 4.0.
 mkdir -p %{buildroot}%{fdir}/states/%{fname}
 mkdir -p %{buildroot}%{fdir}/metadata/%{fname}
 cp -R %{fname} %{buildroot}%{fdir}/states
+cp -R %{ftemplates} %{buildroot}%{fdir}/states/%{fname}
 cp -R form.yml %{buildroot}%{fdir}/metadata/%{fname}
 if [ -f metadata.yml ]
 then
@@ -70,6 +73,7 @@ fi
 %dir %attr(0755, root, salt) %{fdir}/metadata
 
 %attr(0755, root, salt) %{fdir}/states/%{fname}
+%attr(0755, root, salt) %{fdir}/states/%{fname}/%{ftemplates}
 %attr(0755, root, salt) %{fdir}/metadata/%{fname}
 
 %changelog

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           habootstrap-formula
-Version:        0.3.5
+Version:        0.3.6
 Group:          System/Packages
 Release:        0
 Summary:        HA cluster (crmsh) deployment salt formula

--- a/pillar.example
+++ b/pillar.example
@@ -42,6 +42,18 @@ cluster:
   #   device:
   #      - /dev/by-label/sbd-disk1
   #      - /dev/by-label/sbd-disk2
+  #   # optional: Configure sbd cluster resource. This updates the resource stonith-sbd created if sbd is enabled
+  #   # Warning: sbd configuration will be overwritten if the resource is defined in the configure template later
+  #   configure_resource:
+  #     #force: False # Force commit. Use with caution, this can allow invalid parameters in the configuration
+  #     params:
+  #       pcmk_delay_max: 15
+  #     op:
+  #       monitor:
+  #        timeout: 15
+  #        interval: 15
+  #     meta:
+  #       resource-stickiness: 3000
 
   # optional: Install required packages to run the cluster (true by default)
   # pre-configured packages sometimes exist for development purposes
@@ -106,6 +118,7 @@ cluster:
   #   url: path_to_configfile
   #   method: update # update by default
   #   is_xml: False # False by default
+  #   force: False # Force commit. Use with caution, this can allow invalid parameters in the configuration. False by default
   #   # optional, jinja2 template can be used to create the configuration file.
   #   template:
   #     source: path_to_template

--- a/pillar.example
+++ b/pillar.example
@@ -89,10 +89,23 @@ cluster:
 
   # optional: Configure cluster resource agents and constraints
   # configure:
-  #   method: update
-  #   # optional, url or template, one of them must be used
+  #   # optional, configure cluster properties and defaults. Find more information running man pacemaker-schedulerd
+  #   # add key/value entries for each specific configuration set
+  #   properties:
+  #     stonith-timeout: 144s
+  #     stonith-enabled: true
+  #   rsc_defaults:
+  #     resource-stickiness: 1000
+  #     migration-threshold: 5000
+  #   op_defaults:
+  #     timeout: 600
+  #     record-pending: true
+  #   # optional, url or template file path to configure the cluster with a cluster configuration file
+  #   # Warning: values in the configuration file for properties, rsc_defaults or op_defaults have
+  #   # preference over the previous data in this pillar file, so they will be overwritten
   #   url: path_to_configfile
-  #   is_xml: False
+  #   method: update # update by default
+  #   is_xml: False # False by default
   #   # optional, jinja2 template can be used to create the configuration file.
   #   template:
   #     source: path_to_template

--- a/templates/sbd_resource.j2
+++ b/templates/sbd_resource.j2
@@ -1,0 +1,24 @@
+{# context is coming from configure_sbd_resource.sls #}
+
+primitive stonith-sbd stonith:external/sbd \
+  {%- if configure.params is defined and configure.params|length>0 %}
+  params \
+  {%- for param, value in configure.params.items() %}
+    {{ param }}={{ value }} \
+  {%- endfor %}
+  {%- endif %}
+  {%- if configure.op is defined and configure.op|length>0 %}
+  {%- for op_item, op_values in configure.op.items() %}
+  op \
+    {{ op_item }} \
+    {%- for op_data, op_value in op_values.items() %}
+      {{ op_data }}={{ op_value }} \
+    {%- endfor %}
+  {%- endfor %}
+  {%- endif %}
+  {%- if configure.meta is defined and configure.meta|length>0 %}
+  {%- for meta, value in configure.meta.items() %}
+  meta \
+    {{ meta }}={{ value }} \
+  {%- endfor %}
+  {%- endif %}


### PR DESCRIPTION
- Add new states to configure the cluster properties and defaults.
- Add the option to configure sbd resource options. In some providers the sbd resource options are different, so I think it's better to do it using the pillar file instead of changes in the templates, as sbd is the most standard fencing mechanism.
More info: https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#default-pacemaker-configuration-for-sbd

It depends on: https://github.com/SUSE/salt-shaptools/pull/63

https://bugzilla.suse.com/show_bug.cgi?id=1170702