### PR TITLE
Update the saltstack repo url for build validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest trusty main'
-        key_url: 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest/SALTSTACK-GPG-KEY.pub'
+      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/ bionic main'
+        key_url: 'http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/SALTSTACK-GPG-KEY.pub'
     packages:
         - salt-common
 


### PR DESCRIPTION
Updating the source configuration for salt gpg key in travis build configuration.
The saltstack repo got removed the Ubuntu 14.04 distribution, and we are getting build error in our formulas due to using the old url.