### PR TITLE
Hotfix/fix sbd prevalidation

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.3.10+git.%ct.%h</param>
+    <param name="versionformat">0.3.11+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/cluster/pre_validation.sls
+++ b/cluster/pre_validation.sls
@@ -15,7 +15,7 @@
   {% endif %}
 {% endif %}
 
-{% if cluster.sbd_checkbox is defined %}
+{% if cluster.sbd is defined and cluster.sbd_checkbox is defined %}
 {% if cluster.sbd.diskless_checkbox is defined and cluster.sbd.diskless_checkbox is sameas true %}
 {% do cluster.sbd.update({'device': false}) %}
 {% endif %}

--- a/cluster/pre_validation.sls
+++ b/cluster/pre_validation.sls
@@ -16,12 +16,10 @@
 {% endif %}
 
 {% if cluster.sbd is defined and cluster.sbd_checkbox is defined %}
-{% if cluster.sbd.diskless_checkbox is defined and cluster.sbd.diskless_checkbox is sameas true %}
-{% do cluster.sbd.update({'device': false}) %}
-{% endif %}
-{% endif %}
-
-
-{% if cluster.sbd.configure_sbd_checkbox is not defined or cluster.sbd.configure_sbd_checkbox is sameas false %}
-{% do cluster.sbd.pop('configure_resource', none) %}
+  {% if cluster.sbd.diskless_checkbox is defined and cluster.sbd.diskless_checkbox is sameas true %}
+    {% do cluster.sbd.update({'device': false}) %}
+  {% endif %}
+  {% if cluster.sbd.configure_sbd_checkbox is defined and cluster.sbd.configure_sbd_checkbox is sameas false %}
+    {% do cluster.sbd.pop('configure_resource', none) %}
+  {% endif %}
 {% endif %}

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -2,7 +2,7 @@
 Thu Oct 15 21:33:58 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version bump 0.3.11
- * Update the prevalidation logic to check for valid sbd entries (jsc#SLE-4047)- 
+ * Update the prevalidation logic to check for valid sbd entries (jsc#SLE-4047)
 
 -------------------------------------------------------------------
 Thu Oct  8 20:47:37 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 15 21:33:58 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version bump 0.3.11
+ * Update the prevalidation logic to check for valid sbd entries (jsc#SLE-4047)- 
+
+-------------------------------------------------------------------
 Thu Oct  8 20:47:37 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
 
 - Version bump 0.3.10


### PR DESCRIPTION
When testing with `GCP`, which has native fencing mechanism option, the `sbd` will not exist in `cluster` pillar.
The `jinja` logic, in SUMA form pre-validation state, needs to check if the `sbd` entry exists or not before doing further operations.
For some reason the existing `jinja` logic for sbd check did not work  and the jinja renders the sbd operations even if sbd is not defined.

I have added the check to be more resilient and additional check for the `sbd` entry.
I tested with SUMA form states and will test with deployments as well.
