### PR TITLE
Remove the --no-overwrite-sshkey option

### DIFF
--- a/ci/validate-formula.sh
+++ b/ci/validate-formula.sh
@@ -19,7 +19,6 @@ function generate_cluster_pillar {
       device: '/dev/vdc'
     ntp: pool.ntp.org
     sshkeys:
-      overwrite: true
       password: linux
     resource_agents:
       - SAPHanaSR

--- a/cluster/create.sls
+++ b/cluster/create.sls
@@ -24,7 +24,6 @@ bootstrap-the-cluster:
      - sbd_dev: {{ cluster.sbd.device|json }}
      {% endif %}
      {% endif %}
-     - no_overwrite_sshkey: {{ not cluster.sshkeys.overwrite }}
      {% if cluster.qdevice is defined %}
      {% if cluster.qdevice.qnetd_hostname is defined %}
      - qnetd_hostname: {{ cluster.qdevice.qnetd_hostname }}

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -3,7 +3,5 @@ cluster:
   install_packages: true
   join_timeout: 60
   wait_for_initialization: 20
-  sshkeys:
-    overwrite: false
   remove: []
   monitoring_enabled: false

--- a/cluster/sshkeys.sls
+++ b/cluster/sshkeys.sls
@@ -13,13 +13,6 @@ create_ssh_directory:
 {% if cluster.sshkeys.get('password', False) %}
 {% set password = cluster.sshkeys.get('password') %}
 
-# Create a temporary key to provide access for the joining node to the 1st node
-{% if cluster.sshkeys.overwrite is sameas true %}
-create_key:
-  cmd.run:
-    - name: yes y | sudo ssh-keygen -f /root/.ssh/id_rsa -C 'Cluster key' -N ''
-{% endif %}
-
 copy_ask_pass:
   file.managed:
     - name: /tmp/ssh_askpass
@@ -64,15 +57,4 @@ rm_ssh_pub:
       - copy_ssh_pub
 
 {% endif %}
-{% endif %}
-
-# ssh keys must always exist if overwrite is false or if the node is joining
-{% if cluster.sshkeys.overwrite is sameas false or cluster.init != host %}
-check_sshkey_exists:
-  file.exists:
-    - name: /root/.ssh/id_rsa
-
-check_sshkey_pub_exists:
-  file.exists:
-    - name: /root/.ssh/id_rsa.pub
 {% endif %}

--- a/form.yml
+++ b/form.yml
@@ -215,12 +215,6 @@ cluster:
       $type: boolean
       $default: false
       $optional: true
-    overwrite:
-      $visibleIf: .authorize_keys == true
-      $name: Overwrite current keys
-      $type: boolean
-      $default: false
-      $optional: true
     password:
       $visibleIf: .authorize_keys == true
       $name: First node root password

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Dec 19 10:47:26 UTC 2020 - Aleksei Burlakov <aburlakov@suse.com>
+
+- Remove --no-overwrite-sshkey option from the formula
+
+-------------------------------------------------------------------
 Mon Jan 18 15:20:34 UTC 2021 - Aleksei Burlakov <aburlakov@suse.com>
 
 - qdevice support: it can be created when initializing a cluster

--- a/pillar.example
+++ b/pillar.example
@@ -90,15 +90,10 @@ cluster:
   # hacluster_password: mypassword
 
   # optional: Manage ssh keys usage
-  # If this entry is not set, the formula expects that the sshkeys exist and are authorized among the nodes
-  # Use cases:
-  # 1. ssh keys already exist and nodes are authorized to ssh each other. Don't set this entry
-  # 2. ssh keys already exist but you want to overwrite them with random new keys, set overwrite to true
-  # 3. ssh keys don't exist and you have the 1st node password. Use this example
-  # 4. If ssh keys don't exist and you don't want to set the password here, the cluster cannot be created!
+  # If your nodes don't have ssh keys, you should put the root password here, the system
+  # will make them for you. If there are ssh keys, you can leave this parameter.
+  # (In the previous versions the keys were overwritten sometimes. It happenes no more.)
   # ssheys:
-  #   # Overwrite current keys (new keys are created if no keys are found)
-  #   overwrite: true # false by default
   #   # First node root password. This entry is used to configure the authorized_keys file from the joining nodes
   #   password: admin # not set by default
 

--- a/test/pillar/cluster.sls
+++ b/test/pillar/cluster.sls
@@ -7,5 +7,4 @@ cluster:
     device: /dev/watchdog
   ntp: pool.ntp.org
   sshkeys:
-    overwrite: true
     password: vagrant


### PR DESCRIPTION
The `crm cluster init/join` will create an ssh key if there is none. If there is an ssh key it will remain.