### PR TITLE
Replace require by recommend for salt-formulas-configuration for SLE12

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.3.11+git.%ct.%h</param>
+    <param name="versionformat">0.4.0+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 19 09:38:52 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version bump 0.4.0
+  * Change salt-formulas-configuration requirement in SLE12 codestream
+  to a recommendation
+  (bsc#1177860)
+
+-------------------------------------------------------------------
 Tue Jan 19 08:32:50 UTC 2021 - Aleksei Burlakov <aburlakov@suse.com>
 
 - Remove --no-overwrite-sshkey option from the formula
@@ -30,7 +38,7 @@ Thu Sep  3 06:37:50 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.3.9
   * Add lock mechanism to the cluster join process to avoid issues
-  when multiple nodes are joining in parallel 
+  when multiple nodes are joining in parallel
   (jsc#SLE-4047)
 
 -------------------------------------------------------------------

--- a/habootstrap-formula.spec
+++ b/habootstrap-formula.spec
@@ -30,7 +30,11 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       salt-shaptools
+%if 0%{?suse_version} < 1500
+Recommends:     salt-formulas-configuration
+%else
 Requires:       salt-formulas-configuration
+%endif
 
 %define fname cluster
 %define fdir  %{_datadir}/salt-formulas
@@ -40,6 +44,10 @@ Requires:       salt-formulas-configuration
 HA cluster salt deployment formula. This formula is capable to perform
 the HA cluster bootstrap actions (init, join, remove) using standalone salt
 or via SUSE Manager formulas with forms, available on SUSE Manager 4.0.
+
+In order to use the formula, salt must be available in the system. The package comes automatically
+in SLE15. To use it in SLE12, salt (and it sub-components) comes from the Advanced systems management
+module, which can be added running the `SUSEConnect -p sle-module-adv-systems-management/12/{{ arch }}`
 
 %prep
 %setup -q


### PR DESCRIPTION
Replace `Require` by `Recommend` for `salt-formulas-configuration` for SLE12.

I have increased the version to `0.4.0` as there are other changes before this commit that bring non backward compatible changes.

https://bugzilla.suse.com/show_bug.cgi?id=1177860