### PR TITLE
Hotfix/remove lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: required
 services:
   - docker
 
+dist: bionic
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/ bionic main'
-        key_url: 'http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/SALTSTACK-GPG-KEY.pub'
+      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/3000/ bionic main'
+        key_url: 'http://repo.saltstack.com/apt/ubuntu/18.04/amd64/3000/SALTSTACK-GPG-KEY.pub'
     packages:
         - salt-common
 

--- a/cluster/init.sls
+++ b/cluster/init.sls
@@ -11,7 +11,6 @@ include:
 {% if cluster.ntp is defined %}
   - .ntp
 {% endif %}
-  - .sshkeys
 {% if cluster.watchdog is defined %}
 {% if cluster.watchdog.module is defined %}
   - .watchdog
@@ -22,6 +21,8 @@ include:
 {% elif host in cluster.remove %}
   - .remove
 {% else %}
+  - .wait_cluster
+  - .sshkeys
   - .join
 {% endif %}
 {% if cluster.corosync is defined %}

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -1,19 +1,5 @@
 {%- from "cluster/map.jinja" import cluster with context -%}
 
-wait-for-cluster:
-  http.wait_for_successful_query:
-    - name: 'https://{{ cluster.init }}:7630/monitor?0'
-    - request_interval: 5
-    - status: 200
-    - verify_ssl: false
-    - wait_for: {{ cluster.join_timeout }}
-
-wait-for-total-initialization:
-  cmd.run:
-    - name: 'sleep {{ cluster.wait_for_initialization }}'
-    - require:
-      - wait-for-cluster
-
 check-ssh-connection-availability:
   cmd.run:
     - name: ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes {{ cluster.init }} true

--- a/cluster/sshkeys.sls
+++ b/cluster/sshkeys.sls
@@ -7,11 +7,18 @@ create_ssh_directory:
    - user: root
    - group: root
    - mode: 600
-
-{% if cluster.init != host %}
+   - require:
+     - wait-for-total-initialization
 
 {% if cluster.sshkeys.get('password', False) %}
 {% set password = cluster.sshkeys.get('password') %}
+
+create_key:
+  cmd.run:
+    - name: yes y | sudo ssh-keygen -f /root/.ssh/id_rsa -C 'Cluster Internal on {{ grains['host'] }}' -N ''
+    - unless: 'test -e /root/.ssh/id_rsa'
+    - require:
+      - wait-for-total-initialization
 
 copy_ask_pass:
   file.managed:
@@ -20,6 +27,8 @@ copy_ask_pass:
     - user: root
     - group: root
     - mode: 755
+    - require:
+      - wait-for-total-initialization
 
 copy_ssh_pub:
   cmd.run:
@@ -56,5 +65,4 @@ rm_ssh_pub:
     - require:
       - copy_ssh_pub
 
-{% endif %}
 {% endif %}

--- a/cluster/wait_cluster.sls
+++ b/cluster/wait_cluster.sls
@@ -1,0 +1,15 @@
+{%- from "cluster/map.jinja" import cluster with context -%}
+
+wait-for-cluster:
+  http.wait_for_successful_query:
+    - name: 'https://{{ cluster.init }}:7630/monitor?0'
+    - request_interval: 5
+    - status: 200
+    - verify_ssl: false
+    - wait_for: {{ cluster.join_timeout }}
+
+wait-for-total-initialization:
+  cmd.run:
+    - name: 'sleep {{ cluster.wait_for_initialization }}'
+    - require:
+      - wait-for-cluster

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,10 +1,17 @@
 -------------------------------------------------------------------
-Tue Jan 19 09:38:52 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+Wed Jan 20 08:28:05 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.4.0
   * Change salt-formulas-configuration requirement in SLE12 codestream
   to a recommendation
   (bsc#1177860)
+
+-------------------------------------------------------------------
+Tue Jan 19 09:38:52 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Remove lock states as this is done in crmsh now
+- Fix ssh keys management to run them once the first node is
+  initialized
 
 -------------------------------------------------------------------
 Tue Jan 19 08:32:50 UTC 2021 - Aleksei Burlakov <aburlakov@suse.com>


### PR DESCRIPTION
2 implementations:
1. Remove the lock mechanism usage in the join process. This is already done by crmsh
2. Fix the ssh keys usage. The PR https://github.com/SUSE/habootstrap-formula/pull/68 has broken the functionality if there are not ssh keys beforehand. Now, the ssh keys is created if this doesn't exist. This is only done in the join, as crmsh will create it during the init. We need to have this to avoid password request from crmsh. For that, I have splitted the `wait_cluster` states to a new file, to make the correct order. After that, the sshkeys states are executed and finally the join operation.
This fix is required to send the new `0.4.0` release

PD: I have updated the CI file as recently salt has changed their repositories removing 2019 version packages