### PR TITLE
Remove wait for initialization

### DIFF
--- a/cluster/corosync.sls
+++ b/cluster/corosync.sls
@@ -5,9 +5,9 @@ customize_corosync:
     - name: /etc/corosync/corosync.conf
     - data: {{ cluster.corosync|json }}
 
-corosync_service:
-  service.running:
-    - name: corosync
+reload_corosync_configuration:
+  cmd.run:
+    - name: corosync-cfgtool -R
     - restart: True
     - onchanges:
       - customize_corosync

--- a/cluster/corosync.sls
+++ b/cluster/corosync.sls
@@ -1,15 +1,20 @@
 {%- from "cluster/map.jinja" import cluster with context -%}
+{%- from "cluster/macros/get_crmsh_lock_file.sls" import get_crmsh_lock_file with context %}
 
 customize_corosync:
   crm.corosync_updated:
     - name: /etc/corosync/corosync.conf
     - data: {{ cluster.corosync|json }}
 
-reload_corosync_configuration:
-  cmd.run:
-    - name: corosync-cfgtool -R
-    - restart: True
+restart_corosync_service:
+  service.running:
+    - name: corosync
     - onchanges:
       - customize_corosync
     - watch:
       - customize_corosync
+
+# Release the lock acquired during the create states
+release_lock:
+  cmd.run:
+    - name: rm -rfv {{ get_crmsh_lock_file() }}

--- a/cluster/defaults.yaml
+++ b/cluster/defaults.yaml
@@ -2,7 +2,6 @@ cluster:
   name: hacluster
   install_packages: true
   join_timeout: 60
-  wait_for_initialization: 20
   sshkeys: {}
   remove: []
   monitoring_enabled: false

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -4,7 +4,7 @@ check-ssh-connection-availability:
   cmd.run:
     - name: ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes {{ cluster.init }} true
     - require:
-      - wait-for-total-initialization
+      - wait-for-cluster
 
 join-the-cluster:
   crm.cluster_joined:

--- a/cluster/join.sls
+++ b/cluster/join.sls
@@ -1,10 +1,22 @@
 {%- from "cluster/map.jinja" import cluster with context -%}
+{%- from "cluster/macros/get_crmsh_lock_file.sls" import get_crmsh_lock_file with context %}
 
 check-ssh-connection-availability:
   cmd.run:
     - name: ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes {{ cluster.init }} true
     - require:
       - wait-for-cluster
+
+# Check before join if the cluster join lock is free
+# This is done in the join itself, but as the init process needs to be atomic the lock usage
+# has been extended
+check-join-availability:
+  cmd.run:
+    - name: ssh -T root@{{ cluster.init }} -o StrictHostKeyChecking=no
+        "until [ ! -e {{ get_crmsh_lock_file() }} ];do sleep 5; done"
+    - timeout: {{ cluster.join_timeout }}
+    - require:
+      - check-ssh-connection-availability
 
 join-the-cluster:
   crm.cluster_joined:
@@ -18,7 +30,7 @@ join-the-cluster:
      - interface: {{ cluster.interface }}
      {% endif %}
      - require:
-       - check-ssh-connection-availability
+       - check-join-availability
 
 hawk:
   service.running:

--- a/cluster/macros/get_crmsh_lock_file.sls
+++ b/cluster/macros/get_crmsh_lock_file.sls
@@ -1,0 +1,3 @@
+{% macro get_crmsh_lock_file() -%}
+`python3 -c 'from crmsh import lock; print(lock.Lock.LOCK_DIR)'`
+{%- endmacro %}

--- a/cluster/sshkeys.sls
+++ b/cluster/sshkeys.sls
@@ -8,7 +8,7 @@ create_ssh_directory:
    - group: root
    - mode: 600
    - require:
-     - wait-for-total-initialization
+     - wait-for-cluster
 
 {% if cluster.sshkeys.get('password', False) %}
 {% set password = cluster.sshkeys.get('password') %}
@@ -18,7 +18,7 @@ create_key:
     - name: yes y | sudo ssh-keygen -f /root/.ssh/id_rsa -C 'Cluster Internal on {{ grains['host'] }}' -N ''
     - unless: 'test -e /root/.ssh/id_rsa'
     - require:
-      - wait-for-total-initialization
+      - wait-for-cluster
 
 copy_ask_pass:
   file.managed:
@@ -28,7 +28,7 @@ copy_ask_pass:
     - group: root
     - mode: 755
     - require:
-      - wait-for-total-initialization
+      - wait-for-cluster
 
 copy_ssh_pub:
   cmd.run:

--- a/cluster/sshkeys.sls
+++ b/cluster/sshkeys.sls
@@ -30,21 +30,9 @@ copy_ask_pass:
     - require:
       - wait-for-cluster
 
-copy_ssh_pub:
-  cmd.run:
-    - name: setsid scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-            /root/.ssh/id_rsa.pub root@{{ cluster.init }}:/root/.ssh/{{ grains['host'] }}_id_rsa.pub
-    - env:
-      - SSH_ASKPASS: /tmp/ssh_askpass
-      - DISPLAY: :0
-      - PASS: {{ password }}
-    - require:
-      - copy_ask_pass
-
 authorize_key:
   cmd.run:
-    - name: setsid ssh -T root@{{ cluster.init }} -o StrictHostKeyChecking=no
-            'cat /root/.ssh/{{ grains['host'] }}_id_rsa.pub >> /root/.ssh/authorized_keys'
+    - name: setsid ssh-copy-id root@{{ cluster.init }}
     - unless: setsid ssh -T root@{{ cluster.init }} -o StrictHostKeyChecking=no
               'grep /root/.ssh/{{ grains['host'] }}_id_rsa.pub -f /root/.ssh/authorized_keys'
     - env:
@@ -52,17 +40,6 @@ authorize_key:
       - DISPLAY: :0
       - PASS: {{ password }}
     - require:
-      - copy_ssh_pub
-
-rm_ssh_pub:
-  cmd.run:
-    - name: setsid ssh -T root@{{ cluster.init }} -o StrictHostKeyChecking=no
-            'rm /root/.ssh/{{ grains['host'] }}_id_rsa.pub'
-    - env:
-      - SSH_ASKPASS: /tmp/ssh_askpass
-      - DISPLAY: :0
-      - PASS: {{ password }}
-    - require:
-      - copy_ssh_pub
+      - copy_ask_pass
 
 {% endif %}

--- a/cluster/wait_cluster.sls
+++ b/cluster/wait_cluster.sls
@@ -7,9 +7,3 @@ wait-for-cluster:
     - status: 200
     - verify_ssl: false
     - wait_for: {{ cluster.join_timeout }}
-
-wait-for-total-initialization:
-  cmd.run:
-    - name: 'sleep {{ cluster.wait_for_initialization }}'
-    - require:
-      - wait-for-cluster

--- a/form.yml
+++ b/form.yml
@@ -29,12 +29,6 @@ cluster:
     $optional: true
     $help: Network interface to use for cluster communication
 
-  wait_for_initialization:
-    $type: number
-    $default: 20
-    $optional: true
-    $help: Time in seconds between hawk service is available in the first node and join command is executed
-
   join_timeout:
     $type: number
     $default: 60
@@ -72,7 +66,7 @@ cluster:
       $type: text
       $placeholder: /dev/watchdog
       $optional: true
-  
+
   sbd_checkbox:
     $name: Configure SBD device and SBD cluster resource
     $type: boolean
@@ -139,8 +133,8 @@ cluster:
         $type: boolean
         $default: false
         $optional: true
-        $help: Mark this option to configure SBD resource operations like monitor        
-      op:  
+        $help: Mark this option to configure SBD resource operations like monitor
+      op:
         $name: operation
         $visibleIf: .configure_resource_operations == true
         $type: group

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,9 +1,17 @@
 -------------------------------------------------------------------
+Thu Mar 18 13:19:10 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Remove wait_for_initialization parameter. crmsh implements an
+  internal lock mechanism now that restricts the joining process if
+  the cluster is still being initialized
+- Use ssh-copy-id instead of implenting this feature
+
+-------------------------------------------------------------------
 Wed Jan 27 12:30:35 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.4.1
   * Ass sshkeys to default dictionary to allow usage with this item
-  (bsc#1181453) 
+  (bsc#1181453)
 
 -------------------------------------------------------------------
 Wed Jan 20 08:28:05 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>

--- a/pillar.example
+++ b/pillar.example
@@ -24,10 +24,6 @@ cluster:
   # optional: UDP instead of multicast
   # unicast: True
 
-  # optional: Time in seconds between hawk service is available in the first
-  # node and join command is executed (20s by default)
-  # wait_for_initialization: 20
-
   # optional: Timeout in seconds to join to the cluster
   # join_timeout: 60
 

--- a/test/test_pillars/advanced.yml
+++ b/test/test_pillars/advanced.yml
@@ -7,7 +7,6 @@ cluster:
     device: /dev/watchdog
   interface: 'eth1'
   unicast: true
-  wait_for_initialization: 10
   join_timeout: 120
   admin_ip: 10.20.30.40
   sbd:

--- a/test/test_pillars/generic.yml
+++ b/test/test_pillars/generic.yml
@@ -2,7 +2,6 @@ cluster:
   name: 'hacluster'
   init: $METHOD
   join_timeout: 120
-  wait_for_initialization: 10
   remove: ['hana03']
   interface: 'eth1'
   watchdog:


### PR DESCRIPTION
Remove `wait_for_initialization` parameter. This parameter runs an active sleep to give time to the cluster to finish the initialization in the 1st node. Now that crmsh implements a lock mechanism (https://github.com/ClusterLabs/crmsh/pull/694), this active waiting is not needed, `crmsh` will do it for us.

In order to prevent any further issue, `corosync` configuration file update has been changed, to use the proper tooling instead of restarting the daemon which can create issues. @liangxin1300 Could you confirm that this is a good practice? The exact change in: https://github.com/SUSE/habootstrap-formula/commit/05c2439591215fc84a517044ff7e7d72f4b45345

Finally, I have changed the SSH keys authorization usage to use `ssh-copy-id` instead of implementing this feature.

**Edit:** Pending to test in Azure, which gave most of the problems about this topic in the past
**Edit:** Tested in Azure and worked fine