### PR TITLE
Fix "Cluster is not created yet. Run cluster_initialized before"

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.4.3+git.%ct.%h</param>
+    <param name="versionformat">0.4.4+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/cluster/init.sls
+++ b/cluster/init.sls
@@ -26,6 +26,9 @@ include:
 {% endif %}
 {% if cluster.corosync is defined %}
   - .corosync
+{% if cluster.init == host %}
+  - .wait_cluster
+{% endif %}
 {% endif %}
 {% if host not in cluster.remove %}
   - .configure_resources

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 23 21:48:36 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.4.4
+  * Implement wait on first node or else applying resources too fast will fail due to UNCLEAN node
+
+-------------------------------------------------------------------
 Mon Jun 28 17:24:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.4.3


### PR DESCRIPTION
This fixes https://github.com/SUSE/ha-sap-terraform-deployments/issues/713.

If resources or cluster properties are applied too fast on first node such actions will fail.
The reason is, that the node might still be in `UNCLEAN` state.
e.g.
```
2021-06-14 13:19:31,506 [salt.loaded.int.module.cmdmod:395 ][INFO    ][4417] Executing command '/usr/sbin/crm' in directory '/root'
2021-06-14 13:19:31,981 [salt.loaded.int.module.cmdmod:836 ][ERROR   ][4417] Command '/usr/sbin/crm' failed with return code: 1
2021-06-14 13:19:31,982 [salt.loaded.int.module.cmdmod:838 ][ERROR   ][4417] stdout: Could not connect to the CIB: Transport endpoint is not connected
crm_mon: Error: cluster is not available on this node
ERROR: status: crm_mon (rc=102):
2021-06-14 13:19:31,982 [salt.loaded.int.module.cmdmod:842 ][ERROR   ][4417] retcode: 1
2021-06-14 13:19:31,983 [salt.state       :323 ][ERROR   ][4417] Cluster is not created yet. Run cluster_initialized before
2021-06-14 13:19:31,983 [salt.state       :2063][INFO    ][4417] Completed state [update] at time 13:19:31.983469 (duration_in_ms=478.278)
2021-06-14 13:19:31,984 [salt.state       :1881][INFO    ][4417] Running state [configure-cluster-properties] at time 13:19:31.984224
2021-06-14 13:19:31,984 [salt.state       :1914][INFO    ][4417] Executing state crm.cluster_properties_present for [configure-cluster-properties]
2021-06-14 13:19:31,986 [salt.loaded.int.module.cmdmod:395 ][INFO    ][4417] Executing command '/usr/sbin/crm' in directory '/root'
```

A simple workaround is to add another wait (same one that is already done on the joining nodes).
This should do no harm and only marginally increases the deployment time.

#76 might include an alternative approach but is not ready to be merged yet.
