### PR TITLE
Fix "Cluster is not created yet. Run cluster_initialized before" - 2nd approach

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.4.3+git.%ct.%h</param>
+    <param name="versionformat">0.4.4+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/cluster/corosync.sls
+++ b/cluster/corosync.sls
@@ -13,3 +13,13 @@ corosync_service:
       - customize_corosync
     - watch:
       - customize_corosync
+
+# To prevent failing "crm configre load" commands after corosync restart
+wait-for-corosync-restart:
+  cmd.run:
+    - name: 'crm cluster wait_for_startup'
+    - require:
+      - corosync_service
+    - retry:
+        attempts: 20
+        interval: 10

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 08 11:37:27 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.4.4
+  * Wait for cluster startup after corosync restart
+
+-------------------------------------------------------------------
 Mon Jul 12 09:44:49 UTC 2021 - Cédric Bosdonnat <cbosdonnat@suse.com>
 
 - Add OCFS2 support


### PR DESCRIPTION
To prevent failing `crm configre load` commands after a corosync restart, we have to check that the cluster is up again.