### PR TITLE
fix `cloud_provider` grain on SLES 15 SP4

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.4.4+git.%ct.%h</param>
+    <param name="versionformat">0.4.5+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/cluster/cloud_detection.sls
+++ b/cluster/cloud_detection.sls
@@ -12,3 +12,4 @@ set_cloud_data_in_grains:
   crm.cloud_grains_present:
     - require:
       - install_crmsh
+    - reload_grains: true

--- a/cluster/configure_resources.sls
+++ b/cluster/configure_resources.sls
@@ -39,6 +39,8 @@ configure-cluster-op-defaults:
     - group: root
     - mode: 644
     - template: jinja
+    - require:
+        - set_cloud_data_in_grains
 {% endif %}
 
 configure-the-cluster:

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 25 12:12:57 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.4.5
+  * reload grains after setting cloud_provider (fix SLES 15 SP4)
+  * require set_cloud_data_in_grains to create resources (fix SLES 15 SP4)
+
+-------------------------------------------------------------------
 Mon Sep 08 11:37:27 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.4.4


### PR DESCRIPTION
The latest salt-3004 which is used by SLES 15 SP4 runs ins slightly different order than the older salt version and hits a condition where the `cloud_provider` grains is not set.
This PR makes sure that the grain is set and loaded before the jinja template tries to load it.