### PR TITLE
install socat for gcp load-balancer resource

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">habootstrap-formula</param>
-    <param name="versionformat">0.4.7+git.%ct.%h</param>
+    <param name="versionformat">0.4.8+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/cluster/packages.sls
+++ b/cluster/packages.sls
@@ -70,7 +70,7 @@ install_additional_packages_azure:
         attempts: 3
         interval: 15
     - pkgs:
-      - socat
+      - socat # needed for load-balancer resource
       # needed for azure fence agent
       - {{ python_version }}-azure-mgmt-compute
       - {{ python_version }}-azure-mgmt-resource
@@ -86,6 +86,7 @@ install_additional_packages_gcp:
         attempts: 3
         interval: 15
     - pkgs:
+      - socat # needed for load-balancer resource
       - {{ python_version }}-google-api-python-client # Needed by gcp-vpc-move-route and fence_gce
       - {{ python_version }}-google-auth
       - {{ python_version }}-google-auth-httplib2

--- a/habootstrap-formula.changes
+++ b/habootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 12 07:49:43 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.4.8
+  * install socat for gcp load-balancer resource
+
+-------------------------------------------------------------------
 Thu Aug 11 09:09:01 UTC 2022 - Christian Schneemann <schneemann@b1-systems.de>
 
 - Version bump 0.4.7


### PR DESCRIPTION
This is still missing for the gcp load-balancer feature which was introduced in https://github.com/SUSE/ha-sap-terraform-deployments/pull/793.